### PR TITLE
Make migrations work in Laravel 6

### DIFF
--- a/migrations/2018_09_30_110932_create_forms_table.php
+++ b/migrations/2018_09_30_110932_create_forms_table.php
@@ -21,7 +21,7 @@ class CreateFormsTable extends Migration
         Schema::create('forms', function (Blueprint $table) {
             $table->increments('id');
 
-            $table->unsignedInteger('user_id')->nullable();
+            $table->unsignedBigInteger('user_id')->nullable();
 
             $table->string('name');
             $table->string('visibility');

--- a/migrations/2018_09_30_142113_create_form_submissions_table.php
+++ b/migrations/2018_09_30_142113_create_form_submissions_table.php
@@ -23,7 +23,7 @@ class CreateFormSubmissionsTable extends Migration
 
             $table->unsignedInteger('form_id');
 
-            $table->unsignedInteger('user_id')->nullable();
+            $table->unsignedBigInteger('user_id')->nullable();
 
             $table->text('content');
 


### PR DESCRIPTION
Laravel 6 uses unsignedBigInteger for 'user_id'.