### PR TITLE
Checking if the file was attached

### DIFF
--- a/src/Models/Submission.php
+++ b/src/Models/Submission.php
@@ -178,9 +178,13 @@ class Submission extends Model
         }
 
         // if the type is 'file' then we have to render this as a link
-        if ($type == 'file') {
-            $file_link = Storage::url($this->content[$key]);
-            $str = "<a href='{$file_link}'>{$str}</a>";
+        if ($type == 'file') {		
+		if(isset($this->content[$key])){
+			$file_link = Storage::url($this->content[$key]);
+			$str = "<a href='{$file_link}'>{$str}</a>";
+	    	} else {
+			$str = "No file";
+	    	}
         }
 
         return new HtmlString($str);


### PR DESCRIPTION
This simply checks if a file was attached before returning the file link.
Without this check, the key would not exists thus causing a crash on this line.